### PR TITLE
.5 second delay for ball launch

### DIFF
--- a/src/main/java/frc/robot/commands/LaunchBallTime.java
+++ b/src/main/java/frc/robot/commands/LaunchBallTime.java
@@ -21,7 +21,9 @@ public class LaunchBallTime extends CommandBase {
  //If the button is held this will be called everytime the scheduler runs (~20ms)
  public void initialize() {
     m_startTime = System.currentTimeMillis();
-    m_intakess.launchBall();
+    if (System.currentTimeMillis() - m_startTime >= 500{       //will only proceed once a .5 second or 500 millisecond delay has occurred
+      m_intakess.launchBall();
+   }
  }
 
  @Override


### PR DESCRIPTION
Added a 500 millisecond or .5 second delay before the launch ball command gets called to allow time for the arm to finish raising in autonomous.  This command is only called in auto, and will only be used followed the armup command.